### PR TITLE
Fix for Avada v5

### DIFF
--- a/qtransx-fusion-page-builder-fix/qtrans-fusion-fix.js
+++ b/qtransx-fusion-page-builder-fix/qtrans-fusion-fix.js
@@ -1,10 +1,10 @@
 (function ($) {
     $(window).load(function () {
-        var $fusionButton = $('#fusion-pb-switch-button'),
+        var $fusionButton = $('#fusion_toggle_builder'),
             $languageSwitch = $('.qtranxs-lang-switch-wrap li'),
             isFusionEditor = (function () {
                     return function () {
-                        return $('#ddbuilder').is(':visible');
+                        return $('#fusion_builder_layout').is(':visible');
                     };
                 })();
 


### PR DESCRIPTION
The plugin doesn't work with Fusion Builder 1.1.6 (Avada 5.1.6) anymore, and here is the patch.